### PR TITLE
Change to use api.pinnacle.com

### DIFF
--- a/src/BaseApiClient.php
+++ b/src/BaseApiClient.php
@@ -10,7 +10,7 @@ abstract class BaseApiClient
     protected $api_user;
     protected $api_password;
 
-    protected $baseUrl = 'https://api.pinnaclesports.com';
+    protected $baseUrl = 'https://api.pinnacle.com';
 
     private $client;
 


### PR DESCRIPTION
Pinnacle email:

> Please be aware that our API will no longer be available on api.pinnaclesports.com and should be accessed solely via api.pinnacle.com.
> 
> When will it happen?
> March 21st, 2017